### PR TITLE
Run npm install after building new project

### DIFF
--- a/src/core/cli/new.js
+++ b/src/core/cli/new.js
@@ -2,6 +2,7 @@
 
 const Config = require("../config");
 const fs = require("fs");
+const { spawnSync } = require('child_process');
 
 /**
  * Create a new rails project at the specified directory as the root
@@ -157,4 +158,10 @@ module.exports = function(name, root) {
     `,
     "utf8"
   );
+
+  spawnSync(`npm install`, {
+    stdio: `inherit`,
+    shell: true,
+    cwd: projectDirectory
+  });
 };


### PR DESCRIPTION
Resolves #44 by spawning a child process and running `npm install` as a shell command in the new project directory.